### PR TITLE
Add Neptune logging, improved metrics, and checkpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # vit_tune
+
+## Configuration highlights
+
+- **Neptune logging** – enable via the `neptune` section. Provide `project`, optional `api_token` (or rely on `NEPTUNE_API_TOKEN` env var), `tags`, and `name`. When enabled the training pipeline logs metrics, confusion matrices, dataset statistics, and checkpoint info to Neptune.
+- **Model cache directory** – control where pretrained weights are downloaded from Hugging Face/TIMM with `model.models_dir`.
+- **Checkpointing** – configure with the `checkpoint` section. Specify output directory, frequency (`save_every_epochs`), the metric to monitor (`monitor`), and whether to maximize or minimize it (`mode`). Best checkpoints and periodic checkpoints are saved there.
+- **Class filtering** – classes with fewer than `data.min_samples_per_class` samples are dropped. The retained class distribution is saved to `class_stats.json` and, when Neptune logging is enabled, uploaded as metadata.
+- **Metrics** – weighted F1 score and normalized confusion matrices are computed for validation/test splits. Confusion matrices are also logged to Neptune.
+
+Refer to `config.yaml` for a complete example configuration.

--- a/config.yaml
+++ b/config.yaml
@@ -19,11 +19,22 @@ model:
   name: "vit_large_patch16_448"
   pretrained: true
   drop_path_rate: 0.1
+  models_dir: "./model_cache"
 loss:
   type: "cross_entropy"
   class_weighting: "inv_freq"
   focal_gamma: 2.0
+checkpoint:
+  dir: "./runs/vit_large/checkpoints"
+  save_every_epochs: 5
+  monitor: "val_acc1"
+  mode: "max"
+neptune:
+  enabled: false
+  project: ""
+  api_token: ""
+  tags: []
+  name: null
 out:
   output_dir: "./runs/vit_large"
-  save_every: 5
   seed: 42

--- a/src/engine/train.py
+++ b/src/engine/train.py
@@ -1,9 +1,15 @@
-import os, json
+import json
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+import numpy as np
 import torch
-from torch.utils.data import DataLoader
-from torch.cuda.amp import autocast, GradScaler
-from torch.optim.lr_scheduler import SequentialLR, LinearLR, CosineAnnealingLR
+from sklearn.metrics import f1_score, confusion_matrix
+from torch.cuda.amp import GradScaler, autocast
+from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
+
 from .losses import FocalLoss
+
 
 def accuracy(output, target, topk=(1,)):
     with torch.no_grad():
@@ -18,17 +24,21 @@ def accuracy(output, target, topk=(1,)):
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
 
+
 def build_criterion(cfg, class_weights=None):
     if cfg["loss"]["type"] == "focal":
-        return FocalLoss(gamma=float(cfg["loss"].get("focal_gamma", 2.0)), weight=class_weights)
-    else:
-        return torch.nn.CrossEntropyLoss(weight=class_weights)
+        return FocalLoss(
+            gamma=float(cfg["loss"].get("focal_gamma", 2.0)), weight=class_weights
+        )
+    return torch.nn.CrossEntropyLoss(weight=class_weights)
+
 
 def train_one_epoch(model, loader, optimizer, scaler, device, criterion, cfg):
     model.train()
     total_loss, total_acc, n = 0.0, 0.0, 0
     amp = bool(cfg["train"].get("amp", True))
     grad_clip = float(cfg["train"].get("grad_clip_norm", 0.0))
+    all_preds, all_targets = [], []
     for images, targets in loader:
         images = images.to(device, non_blocking=True)
         targets = targets.to(device, non_blocking=True)
@@ -50,62 +60,245 @@ def train_one_epoch(model, loader, optimizer, scaler, device, criterion, cfg):
             if grad_clip > 0:
                 torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             optimizer.step()
+        preds = logits.argmax(dim=1)
         acc1 = accuracy(logits, targets, topk=(1,))[0].item()
         total_loss += loss.item() * images.size(0)
-        total_acc  += acc1 * images.size(0)
+        total_acc += acc1 * images.size(0)
         n += images.size(0)
-    return {"loss": total_loss / n, "acc1": total_acc / n}
+        all_preds.append(preds.detach().cpu())
+        all_targets.append(targets.detach().cpu())
+    if n == 0:
+        return {"loss": 0.0, "acc1": 0.0, "f1_weighted": 0.0}
+    y_true = torch.cat(all_targets).numpy() if all_targets else np.array([])
+    y_pred = torch.cat(all_preds).numpy() if all_preds else np.array([])
+    f1 = f1_score(y_true, y_pred, average="weighted") if y_true.size else 0.0
+    return {"loss": total_loss / n, "acc1": total_acc / n, "f1_weighted": f1}
+
 
 @torch.no_grad()
-def evaluate(model, loader, device, criterion):
+def evaluate(model, loader, device, criterion, num_classes: int):
     model.eval()
     total_loss, total_acc, n = 0.0, 0.0, 0
+    all_preds, all_targets = [], []
     for images, targets in loader:
         images = images.to(device, non_blocking=True)
         targets = targets.to(device, non_blocking=True)
         logits = model(images)
         loss = criterion(logits, targets)
+        preds = logits.argmax(dim=1)
         acc1 = accuracy(logits, targets, topk=(1,))[0].item()
         total_loss += loss.item() * images.size(0)
-        total_acc  += acc1 * images.size(0)
+        total_acc += acc1 * images.size(0)
         n += images.size(0)
-    return {"loss": total_loss / n, "acc1": total_acc / n}
+        all_preds.append(preds.cpu())
+        all_targets.append(targets.cpu())
+    if n == 0:
+        metrics = {
+            "loss": 0.0,
+            "acc1": 0.0,
+            "f1_weighted": 0.0,
+            "confusion_matrix": np.zeros((num_classes, num_classes), dtype=float),
+        }
+        return metrics
+    y_true = torch.cat(all_targets).numpy()
+    y_pred = torch.cat(all_preds).numpy()
+    f1 = f1_score(y_true, y_pred, average="weighted") if y_true.size else 0.0
+    cm = confusion_matrix(y_true, y_pred, labels=list(range(num_classes)))
+    cm = cm.astype(float)
+    row_sums = cm.sum(axis=1, keepdims=True)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        cm = np.divide(cm, row_sums, where=row_sums != 0)
+    cm[np.isnan(cm)] = 0.0
+    metrics = {
+        "loss": total_loss / n,
+        "acc1": total_acc / n,
+        "f1_weighted": f1,
+        "confusion_matrix": cm,
+    }
+    return metrics
+
 
 def build_schedulers(optimizer, steps_per_epoch, cfg):
     warmup_epochs = int(cfg["train"].get("warmup_epochs", 0))
     epochs = int(cfg["train"]["epochs"])
-    total_steps = steps_per_epoch * epochs
-    warmup_steps = steps_per_epoch * warmup_epochs
+    total_steps = max(1, steps_per_epoch) * epochs
+    warmup_steps = max(1, steps_per_epoch) * warmup_epochs
     if warmup_steps > 0:
         warmup = LinearLR(optimizer, start_factor=0.01, end_factor=1.0, total_iters=warmup_steps)
-        cosine = CosineAnnealingLR(optimizer, T_max=total_steps - warmup_steps)
+        cosine = CosineAnnealingLR(optimizer, T_max=max(1, total_steps - warmup_steps))
         sched = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warmup_steps])
     else:
-        sched = CosineAnnealingLR(optimizer, T_max=total_steps)
+        sched = CosineAnnealingLR(optimizer, T_max=max(1, total_steps))
     return sched
 
-def run_training(model, loaders, optimizer, device, criterion, cfg, out_dir: str):
+
+def _resolve_checkpoint_dir(out_dir: str, checkpoint_cfg: Dict) -> Path:
+    ckpt_cfg_dir = checkpoint_cfg.get("dir")
+    out_path = Path(out_dir)
+    if ckpt_cfg_dir:
+        ckpt_dir = Path(ckpt_cfg_dir)
+        if not ckpt_dir.is_absolute():
+            ckpt_dir = out_path / ckpt_dir
+    else:
+        ckpt_dir = out_path / "checkpoints"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    return ckpt_dir
+
+
+def _save_checkpoint(path: Path, model, optimizer, epoch: int, monitor_name: str, monitor_value: float):
+    payload = {
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "epoch": epoch,
+        monitor_name: monitor_value,
+    }
+    torch.save(payload, path)
+
+
+def _log_confusion_matrix(neptune_run, namespace: str, matrix: np.ndarray, class_names: Sequence[str], step: Optional[int] = None):
+    if neptune_run is None:
+        return
+    matrix_list = matrix.tolist()
+    payload = {"epoch": step, "matrix": matrix_list, "labels": list(class_names)}
+    neptune_run[f"{namespace}/confusion_matrix/data"].append(payload)
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from neptune.types import File
+    except Exception:
+        return
+    fig, ax = plt.subplots(figsize=(max(6, 0.6 * len(class_names)), max(6, 0.6 * len(class_names))))
+    im = ax.imshow(matrix, interpolation="nearest", cmap="Blues")
+    ax.figure.colorbar(im, ax=ax)
+    ax.set(
+        xticks=np.arange(matrix.shape[1]),
+        yticks=np.arange(matrix.shape[0]),
+        xticklabels=class_names,
+        yticklabels=class_names,
+        ylabel="True label",
+        xlabel="Predicted label",
+        title="Normalized Confusion Matrix",
+    )
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
+    thresh = matrix.max() / 2.0 if matrix.size else 0.0
+    for i in range(matrix.shape[0]):
+        for j in range(matrix.shape[1]):
+            ax.text(
+                j,
+                i,
+                f"{matrix[i, j]:.2f}",
+                ha="center",
+                va="center",
+                color="white" if matrix[i, j] > thresh else "black",
+            )
+    fig.tight_layout()
+    neptune_run[f"{namespace}/confusion_matrix/plot"].append(File.as_image(fig), step=step)
+    plt.close(fig)
+
+
+def run_training(
+    model,
+    loaders,
+    optimizer,
+    device,
+    criterion,
+    cfg,
+    out_dir: str,
+    num_classes: int,
+    class_names: Sequence[str],
+    neptune_run=None,
+):
     scaler = GradScaler(enabled=bool(cfg["train"].get("amp", True)))
-    best_acc = -1.0
     epochs = int(cfg["train"]["epochs"])
-    scheduler = build_schedulers(optimizer, steps_per_epoch=len(loaders['train']), cfg=cfg)
+    scheduler = build_schedulers(optimizer, steps_per_epoch=len(loaders["train"]), cfg=cfg)
     history = []
-    for epoch in range(1, epochs+1):
-        tr = train_one_epoch(model, loaders['train'], optimizer, scaler, device, criterion, cfg)
-        va = evaluate(model, loaders['val'], device, criterion)
+
+    checkpoint_cfg = cfg.get("checkpoint", {})
+    ckpt_dir = _resolve_checkpoint_dir(out_dir, checkpoint_cfg)
+    save_every = int(checkpoint_cfg.get("save_every_epochs", cfg.get("out", {}).get("save_every", 0) or 0))
+    monitor = checkpoint_cfg.get("monitor", "val_acc1")
+    mode = checkpoint_cfg.get("mode", "max").lower()
+    if mode not in {"max", "min"}:
+        raise ValueError("Checkpoint mode must be 'max' or 'min'")
+    best_metric = float("-inf") if mode == "max" else float("inf")
+    best_epoch: Optional[int] = None
+    if neptune_run is not None:
+        neptune_run["checkpoints/dir"] = str(ckpt_dir)
+        neptune_run["checkpoints/monitor"] = monitor
+        neptune_run["checkpoints/mode"] = mode
+
+    for epoch in range(1, epochs + 1):
+        tr = train_one_epoch(model, loaders["train"], optimizer, scaler, device, criterion, cfg)
+        va = evaluate(model, loaders["val"], device, criterion, num_classes=num_classes)
         scheduler.step()
-        row = {'epoch': epoch, 'train_loss': tr['loss'], 'train_acc1': tr['acc1'], 'val_loss': va['loss'], 'val_acc1': va['acc1'], 'lr': optimizer.param_groups[0]['lr']}
+        row = {
+            "epoch": epoch,
+            "train_loss": tr["loss"],
+            "train_acc1": tr["acc1"],
+            "train_f1_weighted": tr["f1_weighted"],
+            "val_loss": va["loss"],
+            "val_acc1": va["acc1"],
+            "val_f1_weighted": va["f1_weighted"],
+            "val_confusion_matrix": va["confusion_matrix"].tolist(),
+            "lr": optimizer.param_groups[0]["lr"],
+        }
         history.append(row)
-        print(f"Epoch {epoch:03d}: train_acc={tr['acc1']:.2f} val_acc={va['acc1']:.2f} train_loss={tr['loss']:.4f} val_loss={va['loss']:.4f}")
-        if va['acc1'] > best_acc:
-            best_acc = va['acc1']
-            torch.save({'model': model.state_dict(), 'acc1': best_acc, 'epoch': epoch}, os.path.join(out_dir, 'best.pt'))
-        if (epoch % int(cfg['out'].get('save_every', 5))) == 0:
-            torch.save({'model': model.state_dict(), 'acc1': va['acc1'], 'epoch': epoch}, os.path.join(out_dir, f'epoch_{epoch}.pt'))
-    with open(os.path.join(out_dir, 'history.json'), 'w', encoding='utf-8') as f:
-        import json; json.dump(history, f, ensure_ascii=False, indent=2)
-    te = evaluate(model, loaders['test'], device, criterion)
-    print(f"TEST: acc1={te['acc1']:.2f} loss={te['loss']:.4f}")
-    with open(os.path.join(out_dir, 'test_metrics.json'), 'w', encoding='utf-8') as f:
-        json.dump(te, f, ensure_ascii=False, indent=2)
+        print(
+            f"Epoch {epoch:03d}: train_acc={tr['acc1']:.2f} val_acc={va['acc1']:.2f} "
+            f"train_loss={tr['loss']:.4f} val_loss={va['loss']:.4f} val_f1={va['f1_weighted']:.4f}"
+        )
+
+        current_metric = va.get(monitor)
+        if current_metric is None:
+            raise ValueError(f"Validation metrics do not contain monitor key '{monitor}'")
+        improved = (current_metric > best_metric) if mode == "max" else (current_metric < best_metric)
+        if improved:
+            best_metric = current_metric
+            best_epoch = epoch
+            best_path = ckpt_dir / "best.pt"
+            _save_checkpoint(best_path, model, optimizer, epoch, monitor, current_metric)
+            if neptune_run is not None:
+                neptune_run["checkpoints/best_epoch"] = epoch
+                neptune_run["checkpoints/best_metric"] = float(best_metric)
+
+        if save_every > 0 and epoch % save_every == 0:
+            epoch_path = ckpt_dir / f"epoch_{epoch}.pt"
+            _save_checkpoint(epoch_path, model, optimizer, epoch, monitor, float(current_metric))
+
+        if neptune_run is not None:
+            neptune_run["metrics/train/loss"].append(tr["loss"], step=epoch)
+            neptune_run["metrics/train/acc1"].append(tr["acc1"], step=epoch)
+            neptune_run["metrics/train/f1_weighted"].append(tr["f1_weighted"], step=epoch)
+            neptune_run["metrics/val/loss"].append(va["loss"], step=epoch)
+            neptune_run["metrics/val/acc1"].append(va["acc1"], step=epoch)
+            neptune_run["metrics/val/f1_weighted"].append(va["f1_weighted"], step=epoch)
+            neptune_run["metrics/lr"].append(optimizer.param_groups[0]["lr"], step=epoch)
+            _log_confusion_matrix(neptune_run, "val", va["confusion_matrix"], class_names, step=epoch)
+
+    history_path = Path(out_dir) / "history.json"
+    with open(history_path, "w", encoding="utf-8") as f:
+        json.dump(history, f, ensure_ascii=False, indent=2)
+
+    te = evaluate(model, loaders["test"], device, criterion, num_classes=num_classes)
+    print(f"TEST: acc1={te['acc1']:.2f} loss={te['loss']:.4f} f1={te['f1_weighted']:.4f}")
+    test_metrics = {
+        "loss": te["loss"],
+        "acc1": te["acc1"],
+        "f1_weighted": te["f1_weighted"],
+        "confusion_matrix": te["confusion_matrix"].tolist(),
+    }
+    with open(Path(out_dir) / "test_metrics.json", "w", encoding="utf-8") as f:
+        json.dump(test_metrics, f, ensure_ascii=False, indent=2)
+
+    if neptune_run is not None:
+        neptune_run["metrics/test/loss"] = te["loss"]
+        neptune_run["metrics/test/acc1"] = te["acc1"]
+        neptune_run["metrics/test/f1_weighted"] = te["f1_weighted"]
+        _log_confusion_matrix(neptune_run, "test", te["confusion_matrix"], class_names, step=None)
+        if best_epoch is not None:
+            neptune_run["checkpoints/best_metric"] = float(best_metric)
+            neptune_run["checkpoints/best_epoch"] = int(best_epoch)
+
     return history

--- a/train.py
+++ b/train.py
@@ -1,9 +1,14 @@
-import os, json
+import os
+import json
 from pathlib import Path
 from collections import Counter
+from copy import deepcopy
+from typing import Any, Dict, Optional
+
 import torch
 from torch.utils.data import DataLoader
 import torch.optim as optim
+
 from src.utils.config import load_config
 from src.utils.seed import set_seed
 from src.data.indexer import scan_folder
@@ -12,36 +17,160 @@ from src.data.dataset import ImageListDataset
 from src.transforms import build_transforms
 from src.models.build import build_model
 from src.engine.train import run_training, build_criterion
+
+
+def _init_neptune_run(cfg: Dict[str, Any]):
+    neptune_cfg = cfg.get("neptune", {})
+    if not neptune_cfg.get("enabled", False):
+        return None
+    try:
+        import neptune
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Neptune logging requested but neptune package is not installed"
+        ) from exc
+
+    project = neptune_cfg.get("project")
+    if not project:
+        raise ValueError("Neptune project must be provided when logging is enabled")
+    api_token = neptune_cfg.get("api_token") or os.environ.get("NEPTUNE_API_TOKEN")
+    run = neptune.init_run(
+        project=project,
+        api_token=api_token,
+        tags=neptune_cfg.get("tags"),
+        name=neptune_cfg.get("name"),
+    )
+    cfg_to_log = deepcopy(cfg)
+    if "neptune" in cfg_to_log and "api_token" in cfg_to_log["neptune"]:
+        cfg_to_log["neptune"]["api_token"] = "***"
+    run["config"] = cfg_to_log
+    return run
+
+
+def _prepare_model_cache(models_dir: Optional[str]):
+    if not models_dir:
+        return
+    path = Path(models_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("HF_HOME", str(path))
+    os.environ.setdefault("TORCH_HOME", str(path))
+    os.environ.setdefault("TIMM_CACHE_DIR", str(path))
+
+
 def main(cfg_path: str):
     cfg = load_config(cfg_path)
     set_seed(int(cfg["out"].get("seed", 42)))
+
+    out_dir = Path(cfg["out"]["output_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    neptune_run = _init_neptune_run(cfg)
+    _prepare_model_cache(cfg.get("model", {}).get("models_dir"))
+
     pairs = scan_folder(cfg["data"]["dataset_dir"])
-    train_pairs, val_pairs, test_pairs, class_counts = stratified_split(pairs, cfg["data"]["split"], cfg["data"]["min_samples_per_class"])
-    labels = sorted({label for _,label in train_pairs+val_pairs+test_pairs})
-    label_to_idx = {label:i for i,label in enumerate(labels)}
-    idx_to_label = {i:l for l,i in label_to_idx.items()}
+    original_counts = Counter(label for _, label in pairs)
+    train_pairs, val_pairs, test_pairs, class_counts = stratified_split(
+        pairs,
+        cfg["data"]["split"],
+        cfg["data"]["min_samples_per_class"],
+    )
+    class_counts_sorted = dict(sorted(class_counts.items(), key=lambda x: x[0]))
+    class_stats_path = out_dir / "class_stats.json"
+    with open(class_stats_path, "w", encoding="utf-8") as f:
+        json.dump(class_counts_sorted, f, ensure_ascii=False, indent=2)
+    if neptune_run is not None:
+        neptune_run["dataset/class_counts"] = class_counts_sorted
+        neptune_run["dataset/num_classes"] = len(class_counts_sorted)
+        neptune_run["dataset/num_samples"] = sum(class_counts_sorted.values())
+        dropped_counts = {
+            label: count
+            for label, count in sorted(original_counts.items(), key=lambda x: x[0])
+            if label not in class_counts_sorted
+        }
+        if dropped_counts:
+            neptune_run["dataset/dropped_class_counts"] = dropped_counts
+
+    labels = sorted({label for _, label in train_pairs + val_pairs + test_pairs})
+    label_to_idx = {label: i for i, label in enumerate(labels)}
+    idx_to_label = {i: l for l, i in label_to_idx.items()}
     train_tf, val_tf = build_transforms(int(cfg["data"]["image_size"]))
     train_ds = ImageListDataset(train_pairs, label_to_idx, transform=train_tf)
-    val_ds   = ImageListDataset(val_pairs,   label_to_idx, transform=val_tf)
-    test_ds  = ImageListDataset(test_pairs,  label_to_idx, transform=val_tf)
-    num_workers = int(cfg["data"]["num_workers"]); batch_size = int(cfg["train"]["batch_size"])
-    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True,  num_workers=num_workers, pin_memory=True, drop_last=True)
-    val_loader   = DataLoader(val_ds,   batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True)
-    test_loader  = DataLoader(test_ds,  batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True)
-    if cfg["loss"].get("class_weighting","none") == "inv_freq":
-        cnt = Counter([label for _,label in train_pairs])
-        import torch
-        weights = torch.tensor([1.0/max(cnt[l],1) for l in labels], dtype=torch.float32); weights = weights / weights.mean()
+    val_ds = ImageListDataset(val_pairs, label_to_idx, transform=val_tf)
+    test_ds = ImageListDataset(test_pairs, label_to_idx, transform=val_tf)
+    num_workers = int(cfg["data"]["num_workers"])
+    batch_size = int(cfg["train"]["batch_size"])
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
+    )
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    if cfg["loss"].get("class_weighting", "none") == "inv_freq":
+        cnt = Counter([label for _, label in train_pairs])
+        weights = torch.tensor(
+            [1.0 / max(cnt[l], 1) for l in labels], dtype=torch.float32
+        )
+        weights = weights / weights.mean()
     else:
         weights = None
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = build_model(cfg["model"]["name"], num_classes=len(labels), pretrained=bool(cfg["model"].get("pretrained", True)), drop_path_rate=float(cfg["model"].get("drop_path_rate", 0.0)))
+    model = build_model(
+        cfg["model"]["name"],
+        num_classes=len(labels),
+        pretrained=bool(cfg["model"].get("pretrained", True)),
+        drop_path_rate=float(cfg["model"].get("drop_path_rate", 0.0)),
+    )
     model.to(device)
-    optimizer = optim.AdamW(model.parameters(), lr=float(cfg["train"]["lr"]), weight_decay=float(cfg["train"]["weight_decay"]))
+    optimizer = optim.AdamW(
+        model.parameters(),
+        lr=float(cfg["train"]["lr"]),
+        weight_decay=float(cfg["train"]["weight_decay"]),
+    )
     class_weights = weights.to(device) if weights is not None else None
     criterion = build_criterion(cfg, class_weights=class_weights)
-    out_dir = Path(cfg["out"]["output_dir"]); out_dir.mkdir(parents=True, exist_ok=True)
-    with open(out_dir / "labels.json", "w", encoding="utf-8") as f: json.dump(idx_to_label, f, ensure_ascii=False, indent=2)
-    run_training(model, {"train": train_loader, "val": val_loader, "test": test_loader}, optimizer, device, criterion, cfg, str(out_dir))
+    with open(out_dir / "labels.json", "w", encoding="utf-8") as f:
+        json.dump(idx_to_label, f, ensure_ascii=False, indent=2)
+    try:
+        run_training(
+            model,
+            {"train": train_loader, "val": val_loader, "test": test_loader},
+            optimizer,
+            device,
+            criterion,
+            cfg,
+            str(out_dir),
+            num_classes=len(labels),
+            class_names=[idx_to_label[i] for i in range(len(labels))],
+            neptune_run=neptune_run,
+        )
+        if neptune_run is not None:
+            neptune_run["status"] = "completed"
+    except Exception as exc:
+        if neptune_run is not None:
+            neptune_run["status"] = "failed"
+            neptune_run["error/message"] = str(exc)
+        raise
+    finally:
+        if neptune_run is not None:
+            neptune_run.stop()
+
+
 if __name__ == "__main__":
-    import argparse; ap = argparse.ArgumentParser(); ap.add_argument("--config","-c", required=True); args = ap.parse_args(); main(args.config)
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", "-c", required=True)
+    args = ap.parse_args()
+    main(args.config)


### PR DESCRIPTION
## Summary
- integrate optional Neptune logging that records configuration, dataset statistics, metrics, and confusion matrices
- add configurable model cache directory, checkpoint controls, weighted F1 evaluation, and class distribution exports
- document the new configuration options in README and extend the example config

## Testing
- python -m compileall src train.py

------
https://chatgpt.com/codex/tasks/task_e_68d928a07008832f96e2c85ac178c117