### PR TITLE
Add configurable training device and refine Neptune logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - **Neptune logging** – enable via the `neptune` section. Provide `project`, optional `api_token` (or rely on `NEPTUNE_API_TOKEN` env var), `tags`, and `name`. When enabled the training pipeline logs metrics, confusion matrices, dataset statistics, and checkpoint info to Neptune.
 - **Model cache directory** – control where pretrained weights are downloaded from Hugging Face/TIMM with `model.models_dir`.
+- **Device selection** – set `train.device` or pass `--device` when running `train.py` to target a specific accelerator (for example `cuda:0` or `cpu`). If omitted the script auto-selects CUDA when available.
 - **Checkpointing** – configure with the `checkpoint` section. Specify output directory, frequency (`save_every_epochs`), the metric to monitor (`monitor`), and whether to maximize or minimize it (`mode`). Best checkpoints and periodic checkpoints are saved there.
 - **Class filtering** – classes with fewer than `data.min_samples_per_class` samples are dropped. The retained class distribution is saved to `class_stats.json` and, when Neptune logging is enabled, uploaded as metadata.
 - **Metrics** – weighted F1 score and normalized confusion matrices are computed for validation/test splits. Confusion matrices are also logged to Neptune.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ train:
   warmup_epochs: 3
   amp: true
   grad_clip_norm: 1.0
+  device: null  # e.g. "cuda", "cuda:1", or "cpu"; null selects automatically
 model:
   name: "vit_large_patch16_448"
   pretrained: true


### PR DESCRIPTION
## Summary
- allow selecting the training device via configuration or the new `--device` CLI override and log it to Neptune metadata
- sanitize unsupported values when logging the run configuration to Neptune while still storing a JSON snapshot
- document the device option in the README and example configuration file

## Testing
- python -m compileall train.py

------
https://chatgpt.com/codex/tasks/task_e_68d932eeea28832fb3a5582c998ac58c