### PR TITLE
Fix accuracy metric scaling and adopt Neptune logger

### DIFF
--- a/src/loggers/neptune_logger.py
+++ b/src/loggers/neptune_logger.py
@@ -1,0 +1,89 @@
+import os
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+import neptune
+from neptune.utils import stringify_unsupported
+
+try:
+    from dotenv import load_dotenv
+    USE_DOT_ENV = True
+except ImportError:  # pragma: no cover - optional dependency
+    USE_DOT_ENV = False
+
+
+class BaseLogger(ABC):
+    """A base experiment logger class."""
+
+    @abstractmethod
+    def __init__(self, config):
+        """Logs git commit id, dvc hash, environment."""
+        pass
+
+    @abstractmethod
+    def log_hyperparameters(self, params: dict):
+        pass
+
+    @abstractmethod
+    def save_metrics(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def save_plot(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def stop(self):
+        pass
+
+
+class NeptuneLogger(BaseLogger):
+    """A neptune.ai experiment logger class."""
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        env_path = getattr(config, "env_path", None)
+        if USE_DOT_ENV and env_path:
+            load_dotenv(env_path)
+
+        api_token = getattr(config, "api_token", None) or os.environ.get("NEPTUNE_API_TOKEN")
+        if api_token:
+            os.environ.setdefault("NEPTUNE_API_TOKEN", api_token)
+
+        run_kwargs = {
+            "project": getattr(config, "project", None),
+            "api_token": os.environ.get("NEPTUNE_API_TOKEN"),
+            "name": getattr(config, "experiment_name", None),
+            "dependencies": getattr(config, "dependencies_path", None),
+            "with_id": getattr(config, "run_id", None),
+            "tags": getattr(config, "tags", None),
+        }
+        run_kwargs = {k: v for k, v in run_kwargs.items() if v is not None}
+        self.run = neptune.init_run(**run_kwargs)
+
+    def log_hyperparameters(self, params: dict):
+        """Model hyperparameters logging."""
+        self.run["hyperparameters"] = stringify_unsupported(params)
+
+    def save_metrics(
+        self,
+        type_set: str,
+        metric_name: Union[list[str], str],
+        metric_value: Union[list[float], float],
+        step: Optional[int] = None,
+    ):
+        if isinstance(metric_name, list):
+            for p_n, p_v in zip(metric_name, metric_value):
+                self.run[f"{type_set}/{p_n}"].log(p_v, step=step)
+        else:
+            self.run[f"{type_set}/{metric_name}"].log(metric_value, step=step)
+
+    def save_plot(self, type_set, plot_name, plt_fig):
+        self.run[f"{type_set}/{plot_name}"].append(plt_fig)
+
+    def add_tag(self, tag: str):
+        self.run["sys/tags"].add(tag)
+
+    def stop(self):
+        self.run.stop()


### PR DESCRIPTION
## Summary
- ensure top-1 accuracy is tracked as a 0-1 fraction throughout training metrics
- integrate a dedicated Neptune logger wrapper and update training to use it safely
- add the NeptuneLogger implementation with optional dotenv loading and helpers for metrics and plots

## Testing
- python -m compileall train.py src


------
https://chatgpt.com/codex/tasks/task_e_68d93b5dad30832f93a5dd285f708085